### PR TITLE
Add benchmark scenario for high volume reads

### DIFF
--- a/benchmarks/benchmarks_suite_test.go
+++ b/benchmarks/benchmarks_suite_test.go
@@ -26,6 +26,10 @@ var (
 	benchCfg      *config.Benchmark
 	k8sClient     client.Client
 	metricsClient metrics.Client
+
+	defaultRetry       = 5 * time.Second
+	defaulTimeout      = 30 * time.Second
+	defaltLatchTimeout = 2 * time.Minute
 )
 
 func TestBenchmarks(t *testing.T) {

--- a/benchmarks/high_volume_reads_test.go
+++ b/benchmarks/high_volume_reads_test.go
@@ -1,0 +1,92 @@
+package benchmarks_test
+
+import (
+    "sync"
+    "time"
+
+    . "github.com/onsi/ginkgo"
+    . "github.com/onsi/gomega"
+
+    "github.com/observatorium/loki-benchmarks/internal/config"
+    "github.com/observatorium/loki-benchmarks/internal/k8s"
+    "github.com/observatorium/loki-benchmarks/internal/latch"
+    "github.com/observatorium/loki-benchmarks/internal/logger"
+    "github.com/observatorium/loki-benchmarks/internal/metrics"
+    "github.com/observatorium/loki-benchmarks/internal/querier"
+)
+
+var _ = Describe("Scenario: High Volume Reads", func() {
+
+    var (
+        beforeOnce  sync.Once
+        afterOnce   sync.Once
+        scenarioCfg config.HighVolumeReads
+    )
+
+    BeforeEach(func() {
+        scenarioCfg = benchCfg.Scenarios.HighVolumeReads
+
+        beforeOnce.Do(func() {
+            writerCfg := scenarioCfg.Writers
+            readerCfg := scenarioCfg.Readers
+
+            // Deploy the logger to ingest logs
+            err := logger.Deploy(k8sClient, benchCfg.Logger, writerCfg, benchCfg.Loki.PushURL())
+            Expect(err).Should(Succeed(), "Failed to deploy logger")
+
+            err = k8s.WaitForReadyDeployment(k8sClient, benchCfg.Logger.Namespace, benchCfg.Logger.Name, writerCfg.Replicas, defaultRetry, defaulTimeout)
+            Expect(err).Should(Succeed(), "Failed to wait for ready logger deployment")
+
+            // Wait until we ingested enough logs based on startThreshold
+            err = latch.WaitUntilGreaterOrEqual(metricsClient, metrics.DistributorBytesReceivedTotal, readerCfg.StartThreshold, defaltLatchTimeout)
+            Expect(err).Should(Succeed(), "Failed to wait until latch activated")
+
+            // Undeploy logger to assert only read traffic
+            err = logger.Undeploy(k8sClient, benchCfg.Logger)
+            Expect(err).Should(Succeed(), "Failed to delete logger deployment")
+
+            // Deploy the query clients
+            err = querier.Deploy(k8sClient, benchCfg.Querier, readerCfg, benchCfg.Loki.QueryURL(), readerCfg.Query)
+            Expect(err).Should(Succeed(), "Failed to deploy querier")
+
+            err = k8s.WaitForReadyDeployment(k8sClient, benchCfg.Querier.Namespace, benchCfg.Querier.Name, readerCfg.Replicas, defaultRetry, defaulTimeout)
+            Expect(err).Should(Succeed(), "Failed to wait for ready querier deployment")
+        })
+
+        time.Sleep(scenarioCfg.Samples.Interval)
+    })
+
+    AfterEach(func() {
+        afterOnce.Do(func() {
+            Expect(querier.Undeploy(k8sClient, benchCfg.Querier)).Should(Succeed(), "Failed to delete querier deployment")
+        })
+    })
+
+    Measure("should result in measurements of p99, p50 and avg for all successful read requests to the query frontend", func(b Benchmarker) {
+        job := benchCfg.Metrics.QueryFrontendJob()
+
+        // Record p99 loki_request_duration_seconds_bucket
+        p99, err := metricsClient.RequestDurationOkReadsP99(job, "1m")
+
+        Expect(err).Should(Succeed(), "Failed to read p50 for all query frontend reads with status code 2xx")
+        Expect(p99).Should(BeNumerically("<", scenarioCfg.P99), "p99 should not exceed expectation")
+
+        b.RecordValue("All query frontend 2xx reads p99", p99)
+
+        // Record p50 loki_request_duration_seconds_bucket
+        p50, err := metricsClient.RequestDurationOkReadsP50(job, "1m")
+
+        Expect(err).Should(Succeed(), "Failed to read p50 for all query frontend reads with status code 2xx")
+        Expect(p50).Should(BeNumerically("<", scenarioCfg.P50), "p50 should not exceed expectation")
+
+        b.RecordValue("All query frontend 2xx reads p50", p50)
+
+        // Record avg from loki_request_duration_seconds_sum / loki_request_duration_seconds_count
+        avg, err := metricsClient.RequestDurationOkReadsAvg(job, "1m")
+
+        Expect(err).Should(Succeed(), "Failed to read average for all query frontend reads with status code 2xx")
+        Expect(avg).Should(BeNumerically("<", scenarioCfg.AVG), "avg should not exceed expectation")
+
+        b.RecordValue("All query frontend 2xx reads avg", avg)
+    }, 10)
+})

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -3,19 +3,44 @@ logger:
   namespace: default
   image: quay.io/periklis/logger:latest
   tenantId: observatorium
-  replicas: 10
-  throughput: 100
+
+querier:
+  name: querier
+  namespace: default
+  image: docker.io/debian
+  tenantId: observatorium
 
 metrics:
   url: http://127.0.0.1:9090
   jobs:
     distributor: loki-distributor
+    ingester: loki-ingester
+    queryFrontend: loki-query-frontend
 
 loki:
-  url: http://observatorium-xyz-loki-distributor-http.observatorium.svc.cluster.local:3100/loki/api/v1
+  distributor: http://observatorium-xyz-loki-distributor-http.observatorium.svc.cluster.local:3100
+  queryFrontend: http://observatorium-xyz-loki-query-frontend-http.observatorium.svc.cluster.local:3100
 
 scenarios:
+  highVolumeReads:
+    samples:
+      interval: "5s"
+    writers:
+      replicas: 10
+      throughput: 100
+    readers:
+      replicas: 2
+      query: 'query=sum(rate({component!=""}[1h])) by (level)'
+      startThreshold: 1024000
+    p99: 0.3
+    p50: 0.2
+    avg: 2.0
   highVolumeWrites:
+    samples:
+      interval: "5s"
+    writers:
+      replicas: 10
+      throughput: 100
     p99: 0.3
     p50: 0.2
     avg: 2.0

--- a/config/prometheus/config.yaml
+++ b/config/prometheus/config.yaml
@@ -1,5 +1,9 @@
 global:
 scrape_configs:
+  - job_name: 'loki-query-frontend'
+    scrape_interval: 1s
+    static_configs:
+    - targets: ['localhost:3100']
   - job_name: 'loki-distributor'
     scrape_interval: 1s
     static_configs:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,14 +1,22 @@
 package config
 
-import "fmt"
+import (
+    "fmt"
+    "time"
+)
 
 type Logger struct {
-    Name       string `yaml:"name"`
-    Namespace  string `yaml:"namespace"`
-    Image      string `yaml:"image"`
-    TenantID   string `yaml:"tenantId"`
-    Replicas   int32  `yaml:"replicas"`
-    Throughput int32  `yaml:"throughput"`
+    Name      string `yaml:"name"`
+    Namespace string `yaml:"namespace"`
+    Image     string `yaml:"image"`
+    TenantID  string `yaml:"tenantId"`
+}
+
+type Querier struct {
+    Name      string `yaml:"name"`
+    Namespace string `yaml:"namespace"`
+    Image     string `yaml:"image"`
+    TenantID  string `yaml:"tenantId"`
 }
 
 type Metrics struct {
@@ -24,30 +32,72 @@ func (m *Metrics) DistributorJob() string {
     return job
 }
 
+func (m *Metrics) QueryFrontendJob() string {
+    job, ok := m.Jobs["queryFrontend"]
+    if !ok {
+        return ""
+    }
+    return job
+}
+
 type Loki struct {
-    URL string `yaml:"url"`
+    Distributor   string `yaml:"distributor"`
+    QueryFrontend string `yaml:"queryFrontend"`
 }
 
 func (lc *Loki) PushURL() string {
-    return fmt.Sprintf("%s/push", lc.URL)
+    return fmt.Sprintf("%s/loki/api/v1/push", lc.Distributor)
 }
 
 func (lc *Loki) QueryURL() string {
-    return fmt.Sprintf("%s/query", lc.URL)
+    return fmt.Sprintf("%s/loki/api/v1/query_range", lc.QueryFrontend)
+}
+
+type Writers struct {
+    Replicas   int32 `yaml:"replicas"`
+    Throughput int32 `yaml:"throughput"`
+}
+
+type Readers struct {
+    Replicas       int32   `yaml:"replicas"`
+    Query          string  `yaml:"query"`
+    StartThreshold float64 `yaml:"startThreshold"`
+}
+
+type Samples struct {
+    Interval time.Duration `yaml:"interval"`
 }
 
 type HighVolumeWrites struct {
     P99 float64 `yaml:"p99"`
     P50 float64 `yaml:"p50"`
     AVG float64 `yaml:"avg"`
+
+    Writers *Writers `yaml:"writers,omitempty"`
+    Readers *Readers `yaml:"readers,omitempty"`
+
+    Samples Samples `yaml:"samples"`
+}
+
+type HighVolumeReads struct {
+    P99 float64 `yaml:"p99"`
+    P50 float64 `yaml:"p50"`
+    AVG float64 `yaml:"avg"`
+
+    Writers *Writers `yaml:"writers,omitempty"`
+    Readers *Readers `yaml:"readers,omitempty"`
+
+    Samples Samples `yaml:"samples"`
 }
 
 type Scenarios struct {
     HighVolumeWrites HighVolumeWrites `yaml:"highVolumeWrites"`
+    HighVolumeReads  HighVolumeReads  `yaml:"highVolumeReads"`
 }
 
 type Benchmark struct {
     Logger    *Logger    `yaml:"logger"`
+    Querier   *Querier   `yaml:"querier"`
     Metrics   *Metrics   `yaml:"metrics"`
     Loki      *Loki      `yaml:"loki"`
     Scenarios *Scenarios `yaml:"scenarios"`

--- a/internal/latch/wait_until.go
+++ b/internal/latch/wait_until.go
@@ -1,0 +1,39 @@
+package latch
+
+import (
+    "fmt"
+    "time"
+
+    "github.com/observatorium/loki-benchmarks/internal/metrics"
+)
+
+func WaitUntilGreaterOrEqual(m metrics.Client, lm metrics.MetricType, threshold float64, timeout time.Duration) error {
+    deadline := time.Now().Add(timeout)
+
+    for {
+        if time.Now().UnixNano() == deadline.UnixNano() {
+            return fmt.Errorf("deadline exceeded waiting for latch activation: %s", string(lm))
+        }
+
+        var (
+            sample float64
+            err    error
+        )
+
+        switch lm {
+        case metrics.DistributorBytesReceivedTotal:
+            sample, err = m.DistributorBytesReceivedTotal()
+            if err != nil {
+                return err
+            }
+        default:
+            return fmt.Errorf("unsupported latch metric: %s", string(lm))
+        }
+
+        if sample >= threshold {
+            break
+        }
+    }
+
+    return nil
+}

--- a/internal/metrics/client.go
+++ b/internal/metrics/client.go
@@ -10,7 +10,19 @@ import (
     "github.com/prometheus/common/model"
 )
 
+type MetricType string
+
+const (
+    DistributorBytesReceivedTotal MetricType = "loki_distributor_bytes_received_total"
+)
+
 type Client interface {
+    DistributorBytesReceivedTotal() (float64, error)
+
+    RequestDurationOkReadsAvg(job, duration string) (float64, error)
+    RequestDurationOkReadsP50(job, duration string) (float64, error)
+    RequestDurationOkReadsP99(job, duration string) (float64, error)
+
     RequestDurationOkWritesAvg(job, duration string) (float64, error)
     RequestDurationOkWritesP50(job, duration string) (float64, error)
     RequestDurationOkWritesP99(job, duration string) (float64, error)

--- a/internal/metrics/distributor.go
+++ b/internal/metrics/distributor.go
@@ -1,0 +1,5 @@
+package metrics
+
+func (c *client) DistributorBytesReceivedTotal() (float64, error) {
+    return c.executeScalarQuery(`loki_distributor_bytes_received_total`)
+}

--- a/internal/metrics/reads.go
+++ b/internal/metrics/reads.go
@@ -1,0 +1,34 @@
+package metrics
+
+import "fmt"
+
+func (c *client) RequestDurationOkReadsAvg(job, duration string) (float64, error) {
+    query := fmt.Sprintf(
+        `100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="%s", method="GET", status_code=~"2.*"}[%s])) / sum by (job) (rate(loki_request_duration_seconds_count{job="%s", method="GET", status_code=~"2.*"}[%s])))`,
+        job,
+        duration,
+        job,
+        duration,
+    )
+
+    return c.executeScalarQuery(query)
+}
+
+func (c *client) RequestDurationOkReadsP50(job, duration string) (float64, error) {
+    return c.requestDurationOkReads(job, duration, 50)
+}
+
+func (c *client) RequestDurationOkReadsP99(job, duration string) (float64, error) {
+    return c.requestDurationOkReads(job, duration, 99)
+}
+
+func (c *client) requestDurationOkReads(job, duration string, percentile int) (float64, error) {
+    query := fmt.Sprintf(
+        `histogram_quantile(0.%d, sum by (job, le) (rate(loki_request_duration_seconds_bucket{job="%s", method="GET", status_code=~"2.*"}[%s])))`,
+        percentile,
+        job,
+        duration,
+    )
+
+    return c.executeScalarQuery(query)
+}

--- a/reports/README.template
+++ b/reports/README.template
@@ -29,3 +29,26 @@ Query:
 > 100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="loki-distributor", method="POST", status_code=~"2.*"}[1m])) / sum by (job) (rate(loki_request_duration_seconds_count{job="loki-distributor", method="POST", status_code=~"2.*"}[1m])))
 
 ![./All-distributor-2xx-Writes-avg.gnuplot.png](./All-distributor-2xx-Writes-avg.gnuplot.png)
+
+### Scenario 2: High Volume Reads
+
+#### P99
+
+Query:
+> histogram_quantile(0.99, sum by (job, le) (rate(loki_request_duration_seconds_bucket{job="loki-query-frontend", method="POST", status_code=~"2.*"}[1m])))
+
+![./All-query-frontend-2xx-reads-p99.gnuplot.png](./All-query-frontend-2xx-reads-p99.gnuplot.png)
+
+#### P50
+
+Query:
+> histogram_quantile(0.50, sum by (job, le) (rate(loki_request_duration_seconds_bucket{job="loki-query-frontend", method="POST", status_code=~"2.*"}[1m])))
+
+![./All-query-frontend-2xx-reads-p50.gnuplot.png](./All-query-frontend-2xx-reads-p50.gnuplot.png)
+
+#### Average
+
+Query:
+> 100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="loki-query-frontend", method="POST", status_code=~"2.*"}[1m])) / sum by (job) (rate(loki_request_duration_seconds_count{job="loki-query-frontend", method="POST", status_code=~"2.*"}[1m])))
+
+![./All-query-frontend-2xx-reads-avg.gnuplot.png](./All-query-frontend-2xx-reads-avg.gnuplot.png)


### PR DESCRIPTION
This PR adds an benchmark test scenario for high volume read request to Loki. It is still work in progress.

Work to be done:
* [x] Bootstrap a high volume of logs into Loki before doing queries, e.g. logs ingestion based on a min threshold.
* [x] Finish querier deployment to to fetch a high volume of logs from query frontend.