### PR TITLE
Drop assertions for measurements

### DIFF
--- a/benchmarks/high_volume_reads_test.go
+++ b/benchmarks/high_volume_reads_test.go
@@ -67,26 +67,17 @@ var _ = Describe("Scenario: High Volume Reads", func() {
 
         // Record p99 loki_request_duration_seconds_bucket
         p99, err := metricsClient.RequestDurationOkReadsP99(job, "1m")
-
         Expect(err).Should(Succeed(), "Failed to read p50 for all query frontend reads with status code 2xx")
-        Expect(p99).Should(BeNumerically("<", scenarioCfg.P99), "p99 should not exceed expectation")
-
         b.RecordValue("All query frontend 2xx reads p99", p99)
 
         // Record p50 loki_request_duration_seconds_bucket
         p50, err := metricsClient.RequestDurationOkReadsP50(job, "1m")
-
         Expect(err).Should(Succeed(), "Failed to read p50 for all query frontend reads with status code 2xx")
-        Expect(p50).Should(BeNumerically("<", scenarioCfg.P50), "p50 should not exceed expectation")
-
         b.RecordValue("All query frontend 2xx reads p50", p50)
 
         // Record avg from loki_request_duration_seconds_sum / loki_request_duration_seconds_count
         avg, err := metricsClient.RequestDurationOkReadsAvg(job, "1m")
-
         Expect(err).Should(Succeed(), "Failed to read average for all query frontend reads with status code 2xx")
-        Expect(avg).Should(BeNumerically("<", scenarioCfg.AVG), "avg should not exceed expectation")
-
         b.RecordValue("All query frontend 2xx reads avg", avg)
     }, 10)
 })

--- a/benchmarks/high_volume_writes_test.go
+++ b/benchmarks/high_volume_writes_test.go
@@ -47,28 +47,18 @@ var _ = Describe("Scenario: High Volume Writes", func() {
 
 		// Record p99 loki_request_duration_seconds_bucket
 		p99, err := metricsClient.RequestDurationOkWritesP99(job, "1m")
-
 		Expect(err).Should(Succeed(), "Failed to read p50 for all distributor writes with status code 2xx")
-		Expect(p99).Should(BeNumerically("<", scenarioCfg.P99), "p99 should not exceed expectation")
-
 		b.RecordValue("All distributor 2xx Writes p99", p99)
 
 		// Record p50 loki_request_duration_seconds_bucket
 		p50, err := metricsClient.RequestDurationOkWritesP50(job, "1m")
-
 		Expect(err).Should(Succeed(), "Failed to read p50 for all distributor writes with status code 2xx")
-		Expect(p50).Should(BeNumerically("<", scenarioCfg.P50), "p50 should not exceed expectation")
-
 		b.RecordValue("All distributor 2xx Writes p50", p50)
 
 		// Record avg from loki_request_duration_seconds_sum / loki_request_duration_seconds_count
 		avg, err := metricsClient.RequestDurationOkWritesAvg(job, "1m")
-
 		Expect(err).Should(Succeed(), "Failed to read average for all distributor writes with status code 2xx")
-		Expect(avg).Should(BeNumerically("<", scenarioCfg.AVG), "avg should not exceed expectation")
-
 		b.RecordValue("All distributor 2xx Writes avg", avg)
-
 	}, 10)
 
 })

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -32,15 +32,9 @@ scenarios:
       replicas: 2
       query: 'query=sum(rate({component!=""}[1h])) by (level)'
       startThreshold: 1024000
-    p99: 0.3
-    p50: 0.2
-    avg: 2.0
   highVolumeWrites:
     samples:
       interval: "5s"
     writers:
       replicas: 10
       throughput: 100
-    p99: 0.3
-    p50: 0.2
-    avg: 2.0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,25 +69,15 @@ type Samples struct {
 }
 
 type HighVolumeWrites struct {
-    P99 float64 `yaml:"p99"`
-    P50 float64 `yaml:"p50"`
-    AVG float64 `yaml:"avg"`
-
-    Writers *Writers `yaml:"writers,omitempty"`
+    Samples Samples  `yaml:"samples"`
     Readers *Readers `yaml:"readers,omitempty"`
-
-    Samples Samples `yaml:"samples"`
+    Writers *Writers `yaml:"writers,omitempty"`
 }
 
 type HighVolumeReads struct {
-    P99 float64 `yaml:"p99"`
-    P50 float64 `yaml:"p50"`
-    AVG float64 `yaml:"avg"`
-
-    Writers *Writers `yaml:"writers,omitempty"`
+    Samples Samples  `yaml:"samples"`
     Readers *Readers `yaml:"readers,omitempty"`
-
-    Samples Samples `yaml:"samples"`
+    Writers *Writers `yaml:"writers,omitempty"`
 }
 
 type Scenarios struct {


### PR DESCRIPTION
This PR drops benchmark assertions for measurements as they are likely to provide less valuable information than graphing the measurements.