### PR TITLE
Add reasonable measurements parameters

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -26,8 +26,8 @@ loki:
 scenarios:
   highVolumeReads:
     samples:
-      interval: "5s"
-      range: "1m"
+      interval: "30s"
+      range: "300s"
       total: 10
     writers:
       replicas: 10
@@ -38,8 +38,8 @@ scenarios:
       startThreshold: 1024000
   highVolumeWrites:
     samples:
-      interval: "5s"
-      range: "1m"
+      interval: "30s"
+      range: "300s"
       total: 10
     writers:
       replicas: 10

--- a/config/prometheus/config.yaml
+++ b/config/prometheus/config.yaml
@@ -1,18 +1,21 @@
 global:
+  scrape_interval: 10s
+  scrape_timeout: 10s
+  evaluation_interval: 10s
 scrape_configs:
   - job_name: 'loki-query-frontend'
-    scrape_interval: 1s
+    scrape_interval: 10s
     static_configs:
     - targets: ['localhost:3100']
   - job_name: 'loki-distributor'
-    scrape_interval: 1s
+    scrape_interval: 10s
     static_configs:
     - targets: ['localhost:3101']
   - job_name: 'loki-ingester'
-    scrape_interval: 1s
+    scrape_interval: 10s
     static_configs:
     - targets: ['localhost:3102']
   - job_name: 'loki-querier'
-    scrape_interval: 1s
+    scrape_interval: 10s
     static_configs:
     - targets: ['localhost:3103']

--- a/run.sh
+++ b/run.sh
@@ -96,7 +96,7 @@ bench() {
     echo -e "\nFoward ports to loki deployments"
     forward_ports
 
-    echo -e "\n Scrape metrics from Loki deployments"
+    echo -e "\nScrape metrics from Loki deployments"
     scrape_loki_metrics
 
     source .bingo/variables.env


### PR DESCRIPTION
This PR addresses for presentation purposes the default parameters for measurements taken in the development environment. It demonstrates that the configuration of the prometheus scraping internal, the sample collection interval as well as the selection of a proper sample range duration play together to make reasonable measurements. For example:

Assuming:
- a metrics scrape interval of `10s` for all loki jobs, 
- a sample interval of `30s` and 
- a sample range duration of `300s`, 

we can gather a p99, p50 and avg latency value for each sample by looking on data points of the last `5m`. Latter is a valid time range that enables looking on enough scraped data points to use `histogram_quantile` w/o running into a `NaN` result.