### PR TITLE
Add QPS measurements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 This suite consists of benchmarks tests for the following Loki scenarios. Each scenario asserts recorded measurements against a selected profile from the [config](./config) directory:
 
-1. **High Volume Writes**: Measure `p99`, `p50` and `avg` request duration for all 2xx write requests to all Loki distributor and ingester pods.
-2. **High Volume Reads**: Measure `p99`, `p50` and `avg` request duration for all 2xx read requests to all Loki query-frontend, querier and ingester pods.
-3. **High Volume Aggregate**: Measure `p99`, `p50` and `avg` request duration for all 2xx read requests to all Loki query-frontend, querier and ingester pods.
+1. **High Volume Writes**: Measure `QPS`, `p99`, `p50` and `avg` request duration for all 2xx write requests to all Loki distributor and ingester pods.
+2. **High Volume Reads**: Measure `QPS`, `p99`, `p50` and `avg` request duration for all 2xx read requests to all Loki query-frontend, querier and ingester pods.
+3. **High Volume Aggregate**: Measure `QPS`, `p99`, `p50` and `avg` request duration for all 2xx read requests to all Loki query-frontend, querier and ingester pods.
 
 ## How to add new benchmarks to this suite
 

--- a/benchmarks/high_volume_aggregate_test.go
+++ b/benchmarks/high_volume_aggregate_test.go
@@ -84,6 +84,11 @@ var _ = Describe("Scenario: High Volume Aggregate", func() {
 		//
 		job := benchCfg.Metrics.QueryFrontendJob()
 
+		// Record Reads QPS
+		qps, err := metricsClient.RequestReadsQPS(job, defaultRange)
+		Expect(err).Should(Succeed(), "Failed to read QPS for all query frontend aggregates with status code 2xx")
+		b.RecordValue("All query frontend 2xx aggregates QPS", qps)
+
 		// Record p99 loki_request_duration_seconds_bucket
 		p99, err := metricsClient.RequestDurationOkQueryP99(job, defaultRange)
 		Expect(err).Should(Succeed(), "Failed to read p99 for all query frontend aggregate reads with status code 2xx")
@@ -104,6 +109,10 @@ var _ = Describe("Scenario: High Volume Aggregate", func() {
 		//
 		job = benchCfg.Metrics.QuerierJob()
 
+		qps, err = metricsClient.RequestReadsQPS(job, defaultRange)
+		Expect(err).Should(Succeed(), "Failed to read QPS for all querier aggregates with status code 2xx")
+		b.RecordValue("All querier 2xx aggregates QPS", qps)
+
 		// Record p99 loki_request_duration_seconds_bucket
 		p99, err = metricsClient.RequestDurationOkQueryP99(job, defaultRange)
 		Expect(err).Should(Succeed(), "Failed to read p99 for all querier query with status code 2xx")
@@ -123,6 +132,15 @@ var _ = Describe("Scenario: High Volume Aggregate", func() {
 		// Collect measurements for the ingester
 		//
 		job = benchCfg.Metrics.IngesterJob()
+
+		// Record Reads QPS
+		qps, err = metricsClient.RequestReadsGrpcQPS(job, defaultRange)
+		Expect(err).Should(Succeed(), "Failed to read QPS for all ingester aggregates with status code 2xx")
+		b.RecordValue("All ingester successful aggregates QPS", qps)
+
+		// Record BoltDB Shipper Reads QPS
+		qps, _ = metricsClient.RequestBoltDBShipperReadsQPS(job, defaultRange)
+		b.RecordValue("All boltdb shipper successful aggregates QPS", qps)
 
 		// Record p99 loki_request_duration_seconds_bucket
 		p99, err = metricsClient.RequestDurationOkGrpcQuerySampleP99(job, defaultRange)

--- a/benchmarks/high_volume_reads_test.go
+++ b/benchmarks/high_volume_reads_test.go
@@ -84,6 +84,11 @@ var _ = Describe("Scenario: High Volume Reads", func() {
 		//
 		job := benchCfg.Metrics.QueryFrontendJob()
 
+		// Record Reads QPS
+		qps, err := metricsClient.RequestReadsQPS(job, defaultRange)
+		Expect(err).Should(Succeed(), "Failed to read QPS for all query frontend reads with status code 2xx")
+		b.RecordValue("All query frontend 2xx reads QPS", qps)
+
 		// Record p99 loki_request_duration_seconds_bucket
 		p99, err := metricsClient.RequestDurationOkQueryRangeP99(job, defaultRange)
 		Expect(err).Should(Succeed(), "Failed to read p50 for all query frontend reads with status code 2xx")
@@ -104,6 +109,11 @@ var _ = Describe("Scenario: High Volume Reads", func() {
 		//
 		job = benchCfg.Metrics.QuerierJob()
 
+		// Record Reads QPS
+		qps, err = metricsClient.RequestReadsQPS(job, defaultRange)
+		Expect(err).Should(Succeed(), "Failed to read QPS for all querier reads with status code 2xx")
+		b.RecordValue("All querier 2xx reads QPS", qps)
+
 		// Record p99 loki_request_duration_seconds_bucket
 		p99, err = metricsClient.RequestDurationOkQueryRangeP99(job, defaultRange)
 		Expect(err).Should(Succeed(), "Failed to read p50 for all querier query-range with status code 2xx")
@@ -123,6 +133,15 @@ var _ = Describe("Scenario: High Volume Reads", func() {
 		// Collect measurements for the ingester
 		//
 		job = benchCfg.Metrics.IngesterJob()
+
+		// Record Reads QPS
+		qps, err = metricsClient.RequestReadsGrpcQPS(job, defaultRange)
+		Expect(err).Should(Succeed(), "Failed to read QPS for all ingester reads with status code 2xx")
+		b.RecordValue("All ingester successful reads QPS", qps)
+
+		// Record BoltDB Shipper Reads QPS
+		qps, _ = metricsClient.RequestBoltDBShipperReadsQPS(job, defaultRange)
+		b.RecordValue("All boltdb shipper successful reads QPS", qps)
 
 		// Record p99 loki_request_duration_seconds_bucket
 		p99, err = metricsClient.RequestDurationOkGrpcQuerySampleP99(job, defaultRange)

--- a/benchmarks/high_volume_writes_test.go
+++ b/benchmarks/high_volume_writes_test.go
@@ -54,6 +54,11 @@ var _ = Describe("Scenario: High Volume Writes", func() {
 		//
 		job := benchCfg.Metrics.DistributorJob()
 
+		// Record Reads QPS
+		qps, err := metricsClient.RequestWritesQPS(job, defaultRange)
+		Expect(err).Should(Succeed(), "Failed to read QPS for all distributor push with status code 2xx")
+		b.RecordValue("All distributor 2xx push QPS", qps)
+
 		// Record p99 loki_request_duration_seconds_bucket
 		p99, err := metricsClient.RequestDurationOkPushP99(job, defaultRange)
 		Expect(err).Should(Succeed(), "Failed to read p99 for all distributor push requests with status code 2xx")
@@ -73,6 +78,15 @@ var _ = Describe("Scenario: High Volume Writes", func() {
 		// Collect measurements for the ingester
 		//
 		job = benchCfg.Metrics.IngesterJob()
+
+		// Record Writes QPS
+		qps, err = metricsClient.RequestWritesGrpcQPS(job, defaultRange)
+		Expect(err).Should(Succeed(), "Failed to read QPS for all ingester GRPC push with status code 2xx")
+		b.RecordValue("All ingester successful GRPC push QPS", qps)
+
+		// Record BoltDB Shipper Writes QPS
+		qps, _ = metricsClient.RequestBoltDBShipperWritesQPS(job, defaultRange)
+		b.RecordValue("All boltdb shipper successful writes QPS", qps)
 
 		// Record p99 loki_request_duration_seconds_bucket
 		p99, err = metricsClient.RequestDurationOkGrpcPushP99(job, defaultRange)

--- a/internal/metrics/boltdb_shipper.go
+++ b/internal/metrics/boltdb_shipper.go
@@ -1,0 +1,11 @@
+package metrics
+
+import "github.com/prometheus/common/model"
+
+func (c *client) RequestBoltDBShipperReadsQPS(job string, duration model.Duration) (float64, error) {
+	return c.requestBoltDBShipperQPS(job, "QUERY", "success", duration)
+}
+
+func (c *client) RequestBoltDBShipperWritesQPS(job string, duration model.Duration) (float64, error) {
+	return c.requestBoltDBShipperQPS(job, "WRITE", "success", duration)
+}

--- a/internal/metrics/grpc.go
+++ b/internal/metrics/grpc.go
@@ -25,3 +25,13 @@ func (c *client) RequestDurationOkGrpcPushP50(job string, duration model.Duratio
 func (c *client) RequestDurationOkGrpcPushP99(job string, duration model.Duration) (float64, error) {
 	return c.requestDurationQuantile(job, "gRPC", "/logproto.Pusher/Push", "success", duration, 99)
 }
+
+func (c *client) RequestReadsGrpcQPS(job string, duration model.Duration) (float64, error) {
+	route := "/logproto.Querier/Query|/logproto.Querier/QuerySample|/logproto.Querier/Label|/logproto.Querier/Series"
+	return c.requestQPS(job, route, "success", duration)
+}
+
+func (c *client) RequestWritesGrpcQPS(job string, duration model.Duration) (float64, error) {
+	route := "/logproto.Pusher/Push"
+	return c.requestQPS(job, route, "success", duration)
+}

--- a/internal/metrics/http.go
+++ b/internal/metrics/http.go
@@ -37,3 +37,13 @@ func (c *client) RequestDurationOkPushP50(job string, duration model.Duration) (
 func (c *client) RequestDurationOkPushP99(job string, duration model.Duration) (float64, error) {
 	return c.requestDurationQuantile(job, "POST", "loki_api_v1_push", "2.*", duration, 99)
 }
+
+func (c *client) RequestReadsQPS(job string, duration model.Duration) (float64, error) {
+	route := "loki_api_v1_series|api_prom_series|api_prom_query|api_prom_label|api_prom_label_name_values|loki_api_v1_query|loki_api_v1_query_range|loki_api_v1_labels|loki_api_v1_label_name_values"
+	return c.requestQPS(job, route, "2.*", duration)
+}
+
+func (c *client) RequestWritesQPS(job string, duration model.Duration) (float64, error) {
+	route := ".*"
+	return c.requestQPS(job, route, "2.*", duration)
+}

--- a/reports/README.template
+++ b/reports/README.template
@@ -2,53 +2,118 @@
 
 This document contains baseline benchmark results for Observatorium Loki under synthetic load.
 
+## Table of Contents
+
+- [Benchmark Profile](#benchmark-profile)
+- [Scenario 1: High Volume Writes](#scenario-1-high-volume-writes)
+  - [Component Distributor](#component-distributor-push)
+    - [QPS](#qps-distributor-push)
+    - [Latency](#latency-distributor-push)
+  - [Component Ingester](#component-ingester-push)
+    - [QPS Ingester](#qps-ingester-push)
+    - [QPS BoltDB Shipper](#qps-boltdb-shipper-push)
+    - [Latency](#latency-distributor-push)
+- [Scenario 2: High Volume Reads](#scenario-2-high-volume-reads)
+  - [Component Query Frontend](#component-query-frontend-reads)
+    - [QPS](#qps-query-frontend-reads)
+    - [Latency](#latency-query-frontend-reads)
+  - [Component Querier](#component-querier-reads)
+    - [QPS](#qps-querier-reads)
+    - [Latency](#latency-querier-reads)
+  - [Component Ingester](#component-ingester-reads)
+    - [QPS Ingester](#qps-ingester-reads)
+    - [QPS BoltDB Shipper](#qps-boltdb-shipper-reads)
+    - [Latency](#latency-ingester-reads)
+- [Scenario 3: High Volume Aggregates](#scenario-3-high-volume-aggregates)
+  - [Component Query Frontend](#component-query-frontend-aggregates)
+    - [QPS](#qps-query-frontend-aggregates)
+    - [Latency](#latency-query-frontend-aggregates)
+  - [Component Querier](#component-querier-aggregates)
+    - [QPS](#qps-querier-aggregates)
+    - [Latency](#latency-querier-aggregates)
+  - [Component Ingester](#component-ingester-aggregates)
+    - [QPS Ingester](#qps-ingester-aggregates)
+    - [QPS BoltDB Shipper](#qps-boltdb-shipper-aggregates)
+    - [Latency](#latency-ingester-aggregates)
+
+---
+
+## Benchmark Profile
+
 Generated using profile:
 [embedmd]:# (../../config/{{TARGET_ENV}}.yaml)
+
+---
 
 ## Results
 
 ### Scenario 1: High Volume Writes
 
-#### Component: Distributor
+#### Component: Distributor Push
 
-##### P99
+##### QPS: Distributor Push
+
+Query:
+> sum(rate(loki_request_duration_seconds_count{job="loki-distributor", route=".*", status_code=~"2.*"}[1m]))
+
+![./All-distributor-2xx-push-QPS.gnuplot.png](./All-distributor-2xx-push-QPS.gnuplot.png)
+
+##### Latency: Distributor Push
+
+###### P99
 
 Query:
 > histogram_quantile(0.99, sum by (job, le) (rate(loki_request_duration_seconds_bucket{job="loki-distributor", method="POST", route="loki_api_v1_push"", status_code=~"2.*"}[1m])))
 
 ![./All-distributor-2xx-push-p99.gnuplot.png](./All-distributor-2xx-push-p99.gnuplot.png)
 
-##### P50
+###### P50
 
 Query:
 > histogram_quantile(0.50, sum by (job, le) (rate(loki_request_duration_seconds_bucket{job="loki-distributor", method="POST", route="loki_api_v1_push"", status_code=~"2.*"}[1m])))
 
 ![./All-distributor-2xx-push-p50.gnuplot.png](./All-distributor-2xx-push-p50.gnuplot.png)
 
-##### Average
+###### Average
 
 Query:
-> 100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="loki-distributor", method="POST", route="loki_api_v1_push"", status_code=~"2.*"}[1m])) / sum by (job) (rate(loki_request_duration_seconds_count{job="loki-distributor", method="POST", route="loki_api_v1_push"", status_code=~"2.*"}[1m])))
+> 100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="loki-distributor", method="POST", route="loki_api_v1_push", status_code=~"2.*"}[1m])) / sum by (job) (rate(loki_request_duration_seconds_count{job="loki-distributor", method="POST", route="loki_api_v1_push", status_code=~"2.*"}[1m])))
 
 ![./All-distributor-2xx-push-avg.gnuplot.png](./All-distributor-2xx-push-avg.gnuplot.png)
 
-#### Component: Ingester
+#### Component: Ingester Push
 
-##### P99
+##### QPS: Ingester Push
+
+Query:
+> sum(rate(loki_request_duration_seconds_count{job="loki-ingester", route="/logproto.Pusher/Push", status_code=~"success"}[1m]))
+
+![./All-ingester-successful-GRPC-push-QPS.gnuplot.png](./All-ingester-successful-GRPC-push-QPS.gnuplot.png)
+
+##### QPS: BoltDB Shipper Push
+
+Query:
+> sum(rate(loki_request_duration_seconds_count{job="loki-ingester", operation="WRITE", status_code=~"success"}[1m]))
+
+![./All-boltdb-shipper-successful-writes-QPS.gnuplot.png](./All-boltdb-shipper-successful-writes-QPS.gnuplot.png)
+
+##### Latency: Ingester Push
+
+###### P99
 
 Query:
 > histogram_quantile(0.99, sum by (job, le) (rate(loki_request_duration_seconds_bucket{job="loki-ingester", method="gRPC", route="/logproto.Pusher/Push", status_code="success"}[1m])))
 
 ![./All-ingester-successful-GRPC-push-p99.gnuplot.png](./All-ingester-successful-GRPC-push-p99.gnuplot.png)
 
-##### P50
+###### P50
 
 Query:
 > histogram_quantile(0.50, sum by (job, le) (rate(loki_request_duration_seconds_bucket{job="loki-ingester", method="gRPC", route="/logproto.Pusher/Push", status_code="success"}[1m])))
 
 ![./All-ingester-successful-GRPC-push-p50.gnuplot.png](./All-ingester-successful-GRPC-push-p50.gnuplot.png)
 
-##### Average
+###### Average
 
 Query:
 > 100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="loki-ingester", method="gRPC", route="/logproto.Pusher/Push", status_code="success"}[1m])) / sum by (job) (rate(loki_request_duration_seconds_count{job="loki-ingester", method="gRPC", route="/logproto.Pusher/Push", status_code="success"}[1m])))
@@ -59,69 +124,103 @@ Query:
 
 ### Scenario 2: High Volume Reads
 
-#### Component: Query Frontend
+#### Component: Query Frontend Reads
 
-##### P99
+##### QPS: Query Frontend Reads
+
+Query:
+> sum(rate(loki_request_duration_seconds_count{job="loki-query-frontend", route="loki_api_v1_series|api_prom_series|api_prom_query|api_prom_label|api_prom_label_name_values|loki_api_v1_query|loki_api_v1_query_range|loki_api_v1_labels|loki_api_v1_label_name_values", status_code=~"2.*"}[1m]))
+
+![./All-query-frontend-2xx-reads-QPS.gnuplot.png](./All-query-frontend-2xx-reads-QPS.gnuplot.png)
+
+##### Latency: Query Frontend Reads
+
+###### P99
 
 Query:
 > histogram_quantile(0.99, sum by (job, le) (rate(loki_request_duration_seconds_bucket{job="loki-query-frontend", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])))
 
 ![./All-query-frontend-2xx-reads-p99.gnuplot.png](./All-query-frontend-2xx-reads-p99.gnuplot.png)
 
-##### P50
+###### P50
 
 Query:
 > histogram_quantile(0.50, sum by (job, le) (rate(loki_request_duration_seconds_bucket{job="loki-query-frontend", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])))
 
 ![./All-query-frontend-2xx-reads-p50.gnuplot.png](./All-query-frontend-2xx-reads-p50.gnuplot.png)
 
-##### Average
+###### Average
 
 Query:
 > 100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="loki-query-frontend", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])) / sum by (job) (rate(loki_request_duration_seconds_count{job="loki-query-frontend", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])))
 
 ![./All-query-frontend-2xx-reads-avg.gnuplot.png](./All-query-frontend-2xx-reads-avg.gnuplot.png)
 
-#### Component: Querier
+#### Component: Querier Reads
 
-##### P99
+##### QPS: Querier Reads
+
+Query:
+> sum(rate(loki_request_duration_seconds_count{job="loki-querier", route="loki_api_v1_series|api_prom_series|api_prom_query|api_prom_label|api_prom_label_name_values|loki_api_v1_query|loki_api_v1_query_range|loki_api_v1_labels|loki_api_v1_label_name_values", status_code=~"2.*"}[1m]))
+
+![./All-querier-2xx-reads-QPS.gnuplot.png](./All-querier-2xx-reads-QPS.gnuplot.png)
+
+##### Latency: Querier Reads
+
+###### P99
 
 Query:
 > histogram_quantile(0.99, sum by (job, le) (rate(loki_request_duration_seconds_bucket{job="loki-querier", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])))
 
 ![./All-querier-2xx-query-range-p99.gnuplot.png](./All-querier-2xx-query-range-p99.gnuplot.png)
 
-##### P50
+###### P50
 
 Query:
 > histogram_quantile(0.50, sum by (job, le) (rate(loki_request_duration_seconds_bucket{job="loki-querier", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])))
 
 ![./All-querier-2xx-query-range-p50.gnuplot.png](./All-querier-2xx-query-range-p50.gnuplot.png)
 
-##### Average
+###### Average
 
 Query:
 > 100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="loki-querier", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])) / sum by (job) (rate(loki_request_duration_seconds_count{job="loki-querier", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])))
 
 ![./All-querier-2xx-query-range-avg.gnuplot.png](./All-querier-2xx-query-range-avg.gnuplot.png)
 
-#### Component: Ingester
+#### Component: Ingester Reads
 
-##### P99
+##### QPS: Ingester Reads
+
+Query:
+> sum(rate(loki_request_duration_seconds_count{job="loki-ingester", route="/logproto.Querier/Query|/logproto.Querier/QuerySample|/logproto.Querier/Label|/logproto.Querier/Series", status_code=~"success"}[1m]))
+
+![./All-ingester-successful-reads-QPS.gnuplot.png](./All-ingester-successful-reads-QPS.gnuplot.png)
+
+##### QPS: BoltDB Shipper Reads
+
+Query:
+> sum(rate(loki_request_duration_seconds_count{job="loki-ingester", operation="QUERY", status_code=~"success"}[1m]))
+
+![./All-boltdb-shipper-successful-reads-QPS.gnuplot.png](./All-boltdb-shipper-successful-reads-QPS.gnuplot.png)
+
+##### Latency: Ingester Reads
+
+###### P99
 
 Query:
 > histogram_quantile(0.99, sum by (job, le) (rate(loki_request_duration_seconds_bucket{job="loki-ingester", method="gRPC", route="/logproto.Querier/QuerySample", status_code="success"}[1m])))
 
 ![./All-ingester-successful-query-sample-p99.gnuplot.png](./All-ingester-successful-query-sample-p99.gnuplot.png)
 
-##### P50
+###### P50
 
 Query:
 > histogram_quantile(0.50, sum by (job, le) (rate(loki_request_duration_seconds_bucket{job="loki-ingester", method="gRPC", route="/logproto.Querier/QuerySample", status_code="success"}[1m])))
 
 ![./All-ingester-successful-query-sample-p50.gnuplot.png](./All-ingester-successful-query-sample-p50.gnuplot.png)
 
-##### Average
+###### Average
 
 Query:
 > 100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="loki-ingester", method="gRPC", route="/logproto.Querier/QuerySample", status_code="success"}[1m])) / sum by (job) (rate(loki_request_duration_seconds_count{job="loki-ingester", method="gRPC", route="/logproto.Querier/QuerySample", status_code="success"}[1m])))
@@ -130,71 +229,105 @@ Query:
 
 ---
 
-### Scenario 3: High Volume Aggregate
+### Scenario 3: High Volume Aggregates
 
-#### Component: Query Frontend
+#### Component: Query Frontend Aggregates
 
-##### P99
+##### QPS: Query Frontend Aggregates
+
+Query:
+> sum(rate(loki_request_duration_seconds_count{job="loki-query-frontend", route="loki_api_v1_series|api_prom_series|api_prom_query|api_prom_label|api_prom_label_name_values|loki_api_v1_query|loki_api_v1_query_range|loki_api_v1_labels|loki_api_v1_label_name_values", status_code=~"2.*"}[1m]))
+
+![./All-query-frontend-2xx-aggregates-QPS.gnuplot.png](./All-query-frontend-2xx-aggregates-QPS.gnuplot.png)
+
+##### Latency: Query Frontend Aggregates
+
+###### P99
 
 Query:
 > histogram_quantile(0.99, sum by (job, le) (rate(loki_request_duration_seconds_bucket{job="loki-query-frontend", method="GET", route="loki_api_v1_query", status_code=~"2.*"}[1m])))
 
 ![./All-query-frontend-2xx-aggregate-reads-p99.gnuplot.png](./All-query-frontend-2xx-aggregate-reads-p99.gnuplot.png)
 
-##### P50
+###### P50
 
 Query:
 > histogram_quantile(0.50, sum by (job, le) (rate(loki_request_duration_seconds_bucket{job="loki-query-frontend", method="GET", route="loki_api_v1_query", status_code=~"2.*"}[1m])))
 
 ![./All-query-frontend-2xx-aggregate-reads-p50.gnuplot.png](./All-query-frontend-2xx-aggregate-reads-p50.gnuplot.png)
 
-##### Average
+###### Average
 
 Query:
 > 100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="loki-query-frontend", method="GET", route="loki_api_v1_query", status_code=~"2.*"}[1m])) / sum by (job) (rate(loki_request_duration_seconds_count{job="loki-query-frontend", method="GET", route="loki_api_v1_query", status_code=~"2.*"}[1m])))
 
 ![./All-query-frontend-2xx-aggregate-reads-avg.gnuplot.png](./All-query-frontend-2xx-aggregate-reads-avg.gnuplot.png)
 
-#### Component: Querier
+#### Component: Querier Aggregates
 
-##### P99
+##### QPS: Querier Aggregates
+
+Query:
+> sum(rate(loki_request_duration_seconds_count{job="loki-querier", route="loki_api_v1_series|api_prom_series|api_prom_query|api_prom_label|api_prom_label_name_values|loki_api_v1_query|loki_api_v1_query_range|loki_api_v1_labels|loki_api_v1_label_name_values", status_code=~"2.*"}[1m]))
+
+![./All-querier-2xx-aggregates-QPS.gnuplot.png](./All-querier-2xx-aggregates-QPS.gnuplot.png)
+
+##### Latency: Querier Aggregates
+
+###### P99
 
 Query:
 > histogram_quantile(0.99, sum by (job, le) (rate(loki_request_duration_seconds_bucket{job="loki-querier", method="GET", route="loki_api_v1_query", status_code=~"2.*"}[1m])))
 
 ![./All-querier-2xx-query-aggregate-p99.gnuplot.png](./All-querier-2xx-query-aggregate-p99.gnuplot.png)
 
-##### P50
+###### P50
 
 Query:
 > histogram_quantile(0.50, sum by (job, le) (rate(loki_request_duration_seconds_bucket{job="loki-querier", method="GET", route="loki_api_v1_query", status_code=~"2.*"}[1m])))
 
 ![./All-querier-2xx-query-aggregate-p50.gnuplot.png](./All-querier-2xx-query-aggregate-p50.gnuplot.png)
 
-##### Average
+###### Average
 
 Query:
 > 100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="loki-querier", method="GET", route="loki_api_v1_query", status_code=~"2.*"}[1m])) / sum by (job) (rate(loki_request_duration_seconds_count{job="loki-querier", method="GET", route="loki_api_v1_query", status_code=~"2.*"}[1m])))
 
 ![./All-querier-2xx-query-aggregate-avg.gnuplot.png](./All-querier-2xx-query-aggregate-avg.gnuplot.png)
 
-#### Component: Ingester
+#### Component: Ingester Aggregates
 
-##### P99
+##### QPS: Ingester Aggregates
+
+Query:
+> sum(rate(loki_request_duration_seconds_count{job="loki-ingester", route="/logproto.Querier/Query|/logproto.Querier/QuerySample|/logproto.Querier/Label|/logproto.Querier/Series", status_code=~"success"}[1m]))
+
+![./All-ingester-successful-aggregates-QPS.gnuplot.png](./All-ingester-successful-aggregates-QPS.gnuplot.png)
+
+##### QPS: BoltDB Shipper Aggregates
+
+Query:
+> sum(rate(loki_request_duration_seconds_count{job="loki-ingester", operation="QUERY", status_code=~"success"}[1m]))
+
+![./All-boltdb-shipper-successful-aggregates-QPS.gnuplot.png](./All-boltdb-shipper-successful-aggregates-QPS.gnuplot.png)
+
+##### Latency: Ingester Aggregates
+
+###### P99
 
 Query:
 > histogram_quantile(0.99, sum by (job, le) (rate(loki_request_duration_seconds_bucket{job="loki-ingester", method="gRPC", route="/logproto.Querier/QuerySample", status_code="success"}[1m])))
 
 ![./All-ingester-successful-query-sample-aggregate-p99.gnuplot.png](./All-ingester-successful-query-sample-aggregate-p99.gnuplot.png)
 
-##### P50
+###### P50
 
 Query:
 > histogram_quantile(0.50, sum by (job, le) (rate(loki_request_duration_seconds_bucket{job="loki-ingester", method="gRPC", route="/logproto.Querier/QuerySample", status_code="success"}[1m])))
 
 ![./All-ingester-successful-query-sample-aggregate-p50.gnuplot.png](./All-ingester-successful-query-sample-aggregate-p50.gnuplot.png)
 
-##### Average
+###### Average
 
 Query:
 > 100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="loki-ingester", method="gRPC", route="/logproto.Querier/QuerySample", status_code="success"}[1m])) / sum by (job) (rate(loki_request_duration_seconds_count{job="loki-ingester", method="gRPC", route="/logproto.Querier/QuerySample", status_code="success"}[1m])))


### PR DESCRIPTION
This PR adds QPS measurements per components for all benchmark tests. I.e.:

- High Volume Reads: QPS for query-frontend, querier, ingester and boltdb-shipper
- High Volume Writes: QPS for distributor, ingester and boltdb-shipper
- High Volume Aggregates: QPS for query-frontend, querier, ingester and boltdb-shipper

BoltDB Shipper QPS is collected if available, because the shipper pushes chunks/indices asynchronously to S3. Thus, these metrics can be collected only if the benchmarks run long enough.