### PR TITLE
Add benchmark for log-based dashboard

### DIFF
--- a/benchmarks/logs_based_dashboard_test.go
+++ b/benchmarks/logs_based_dashboard_test.go
@@ -1,0 +1,161 @@
+package benchmarks_test
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/observatorium/loki-benchmarks/internal/config"
+	"github.com/observatorium/loki-benchmarks/internal/k8s"
+	"github.com/observatorium/loki-benchmarks/internal/latch"
+	"github.com/observatorium/loki-benchmarks/internal/logger"
+	"github.com/observatorium/loki-benchmarks/internal/metrics"
+	"github.com/observatorium/loki-benchmarks/internal/querier"
+)
+
+var _ = Describe("Scenario: Logs-Based Dashboard", func() {
+	var (
+		beforeOnce  sync.Once
+		afterOnce   sync.Once
+		scenarioCfg config.LogsBasedDashboard
+	)
+
+	BeforeEach(func() {
+		scenarioCfg = benchCfg.Scenarios.LogsBasedDashboard
+		if !scenarioCfg.Enabled {
+			Skip("Log Based Dashboard Benchmark not enabled!")
+
+			return
+		}
+
+		beforeOnce.Do(func() {
+			writerCfg := scenarioCfg.Writers
+			readerCfg := scenarioCfg.Readers
+
+			// Deploy the logger to ingest logs
+			err := logger.Deploy(k8sClient, benchCfg.Logger, writerCfg, benchCfg.Loki.PushURL())
+			Expect(err).Should(Succeed(), "Failed to deploy logger")
+
+			err = k8s.WaitForReadyDeployment(k8sClient, benchCfg.Logger.Namespace, benchCfg.Logger.Name, writerCfg.Replicas, defaultRetry, defaulTimeout)
+			Expect(err).Should(Succeed(), "Failed to wait for ready logger deployment")
+
+			// Wait until we ingested enough logs based on startThreshold
+			err = latch.WaitUntilGreaterOrEqual(metricsClient, metrics.DistributorBytesReceivedTotal, readerCfg.StartThreshold, defaultLatchTimeout)
+			Expect(err).Should(Succeed(), "Failed to wait until latch activated")
+
+			// Undeploy logger to assert only read traffic
+			err = logger.Undeploy(k8sClient, benchCfg.Logger)
+			Expect(err).Should(Succeed(), "Failed to delete logger deployment")
+
+			// Deploy the query clients
+			for id, query := range readerCfg.Queries {
+				err = querier.Deploy(k8sClient, benchCfg.Querier, readerCfg, benchCfg.Loki.QueryRangeURL(), id, query)
+				Expect(err).Should(Succeed(), "Failed to deploy querier")
+			}
+
+			for id := range readerCfg.Queries {
+				name := querier.DeploymentName(benchCfg.Querier, id)
+
+				err = k8s.WaitForReadyDeployment(k8sClient, benchCfg.Querier.Namespace, name, readerCfg.Replicas, defaultRetry, defaulTimeout)
+				Expect(err).Should(Succeed(), fmt.Sprintf("Failed to wait for ready querier deployment: %s", name))
+			}
+		})
+
+		time.Sleep(scenarioCfg.Samples.Interval)
+	})
+
+	AfterEach(func() {
+		afterOnce.Do(func() {
+			readerCfg := scenarioCfg.Readers
+			for id := range readerCfg.Queries {
+				Expect(querier.Undeploy(k8sClient, benchCfg.Querier, id)).Should(Succeed(), "Failed to delete querier deployment")
+			}
+		})
+	})
+
+	Measure("should result in measurements of p99, p50 and avg for all successful dashboard read requests", func(b Benchmarker) {
+		defaultRange := scenarioCfg.Samples.Range
+
+		//
+		// Collect measurements for the query frontend
+		//
+		job := benchCfg.Metrics.QueryFrontendJob()
+
+		// Record Reads QPS
+		qps, err := metricsClient.RequestReadsQPS(job, defaultRange)
+		Expect(err).Should(Succeed(), "Failed to read QPS for all query frontend dashboard reads with status code 2xx")
+		b.RecordValue("All query frontend 2xx dashboard reads QPS", qps)
+
+		// Record p99 loki_request_duration_seconds_bucket
+		p99, err := metricsClient.RequestDurationOkQueryRangeP99(job, defaultRange)
+		Expect(err).Should(Succeed(), "Failed to read p50 for all query frontend dashboard reads with status code 2xx")
+		b.RecordValue("All query frontend 2xx dashboard reads p99", p99)
+
+		// Record p50 loki_request_duration_seconds_bucket
+		p50, err := metricsClient.RequestDurationOkQueryRangeP50(job, defaultRange)
+		Expect(err).Should(Succeed(), "Failed to read p50 for all query frontend dashboard reads with status code 2xx")
+		b.RecordValue("All query frontend 2xx dashboard reads p50", p50)
+
+		// Record avg from loki_request_duration_seconds_sum / loki_request_duration_seconds_count
+		avg, err := metricsClient.RequestDurationOkQueryRangeAvg(job, defaultRange)
+		Expect(err).Should(Succeed(), "Failed to read average for all query frontend dashboard reads with status code 2xx")
+		b.RecordValue("All query frontend 2xx dashboard reads avg", avg)
+
+		//
+		// Collect measurements for the querier
+		//
+		job = benchCfg.Metrics.QuerierJob()
+
+		// Record Reads QPS
+		qps, err = metricsClient.RequestReadsQPS(job, defaultRange)
+		Expect(err).Should(Succeed(), "Failed to read QPS for all querier dashboard reads with status code 2xx")
+		b.RecordValue("All querier 2xx dashboard reads QPS", qps)
+
+		// Record p99 loki_request_duration_seconds_bucket
+		p99, err = metricsClient.RequestDurationOkQueryRangeP99(job, defaultRange)
+		Expect(err).Should(Succeed(), "Failed to read p50 for all querier dashboard reads with status code 2xx")
+		b.RecordValue("All querier 2xx dashboard reads p99", p99)
+
+		// Record p50 loki_request_duration_seconds_bucket
+		p50, err = metricsClient.RequestDurationOkQueryRangeP50(job, defaultRange)
+		Expect(err).Should(Succeed(), "Failed to read p50 for all querier dashboard reads with status code 2xx")
+		b.RecordValue("All querier 2xx dashboard reads p50", p50)
+
+		// Record avg from loki_request_duration_seconds_sum / loki_request_duration_seconds_count
+		avg, err = metricsClient.RequestDurationOkQueryRangeAvg(job, defaultRange)
+		Expect(err).Should(Succeed(), "Failed to read average for all querier dashboard reads with status code 2xx")
+		b.RecordValue("All querier 2xx dashboard reads  avg", avg)
+
+		//
+		// Collect measurements for the ingester
+		//
+		job = benchCfg.Metrics.IngesterJob()
+
+		// Record Reads QPS
+		qps, err = metricsClient.RequestReadsGrpcQPS(job, defaultRange)
+		Expect(err).Should(Succeed(), "Failed to read QPS for all ingester dashboard reads with status code 2xx")
+		b.RecordValue("All ingester successful dashboard reads QPS", qps)
+
+		// Record BoltDB Shipper Reads QPS
+		qps, _ = metricsClient.RequestBoltDBShipperReadsQPS(job, defaultRange)
+		b.RecordValue("All boltdb shipper successful dashboard reads QPS", qps)
+
+		// Record p99 loki_request_duration_seconds_bucket
+		p99, err = metricsClient.RequestDurationOkGrpcQuerySampleP99(job, defaultRange)
+		Expect(err).Should(Succeed(), "Failed to read p50 for all ingester dashboard reads with status code 2xx")
+		b.RecordValue("All ingester successful dashboard reads p99", p99)
+
+		// Record p50 loki_request_duration_seconds_bucket
+		p50, err = metricsClient.RequestDurationOkGrpcQuerySampleP50(job, defaultRange)
+		Expect(err).Should(Succeed(), "Failed to read p50 for all ingester dashboard reads with status code 2xx")
+		b.RecordValue("All ingester successful dashboard reads p50", p50)
+
+		// Record avg from loki_request_duration_seconds_sum / loki_request_duration_seconds_count
+		avg, err = metricsClient.RequestDurationOkGrpcQuerySampleAvg(job, defaultRange)
+		Expect(err).Should(Succeed(), "Failed to read average for all ingester dashboard reads with status code 2xx")
+		b.RecordValue("All ingester successful dashboard reads avg", avg)
+	}, benchCfg.Scenarios.LogsBasedDashboard.Samples.Total)
+})

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -63,3 +63,24 @@ scenarios:
         countOverTime: 'query=count_over_time({component!=""}[1h])'
         bytesOverTime: 'query=bytes_over_time({component!=""}[1h])'
       startThreshold: 1024000
+  logsBasedDashboard:
+    enabled: true
+    samples:
+      interval: "30s"
+      range: "300s"
+      total: 10
+    writers:
+      replicas: 10
+      throughput: 100
+    readers:
+      replicas: 1
+      queries:
+        sumRateByLevel: 'query=sum(rate({component!=""}[1m])) by (level)'
+        devopsend: 'query=sum(rate({component="devopsend"}[1m])) by (level)'
+        fullstackend: 'query=sum(rate({component="fullstackend"}[1m])) by (level)'
+        frontend: 'query=sum(rate({component="frontend"}[1m])) by (level)'
+        backend: 'query=sum(rate({component="backend"}[1m])) by (level)'
+        allpanics: 'query=sum(rate({msg=~"panic.*"}[1m]))'
+        countpanics: 'query=count_over_time({msg=~"panic.*"}[5m])'
+        topTenErrors: 'query=topk(10, sum(rate({component!="", level="error"}[1h])) by (component))'
+      startThreshold: 1024000

--- a/config/observatorium-logs-stage.yaml
+++ b/config/observatorium-logs-stage.yaml
@@ -63,3 +63,24 @@ scenarios:
         countOverTime: 'query=count_over_time({component!=""}[1h])'
         bytesOverTime: 'query=bytes_over_time({component!=""}[1h])'
       startThreshold: 1024000
+  logsBasedDashboard:
+    enabled: true
+    samples:
+      interval: "30s"
+      range: "300s"
+      total: 10
+    writers:
+      replicas: 10
+      throughput: 100
+    readers:
+      replicas: 1
+      queries:
+        sumRateByLevel: 'query=sum(rate({component!=""}[1m])) by (level)'
+        devopsend: 'query=sum(rate({component="devopsend"}[1m])) by (level)'
+        fullstackend: 'query=sum(rate({component="fullstackend"}[1m])) by (level)'
+        frontend: 'query=sum(rate({component="frontend"}[1m])) by (level)'
+        backend: 'query=sum(rate({component="backend"}[1m])) by (level)'
+        allpanics: 'query=sum(rate({msg=~"panic.*"}[1m]))'
+        countpanics: 'query=count_over_time({msg=~"panic.*"}[5m])'
+        topTenErrors: 'query=topk(10, sum(rate({component!="", level="error"}[1h])) by (component))'
+      startThreshold: 1024000

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -117,10 +117,18 @@ type HighVolumeAggregate struct {
 	Writers *Writers `yaml:"writers,omitempty"`
 }
 
+type LogsBasedDashboard struct {
+	Enabled bool     `yaml:"enabled"`
+	Samples Samples  `yaml:"samples"`
+	Readers *Readers `yaml:"readers,omitempty"`
+	Writers *Writers `yaml:"writers,omitempty"`
+}
+
 type Scenarios struct {
 	HighVolumeWrites    HighVolumeWrites    `yaml:"highVolumeWrites"`
 	HighVolumeReads     HighVolumeReads     `yaml:"highVolumeReads"`
 	HighVolumeAggregate HighVolumeAggregate `yaml:"highVolumeAggregate"`
+	LogsBasedDashboard  LogsBasedDashboard  `yaml:"logsBasedDashboard"`
 }
 
 type Benchmark struct {

--- a/reports/README.template
+++ b/reports/README.template
@@ -1,6 +1,6 @@
-# Bechmarks Results
+# Benchmark Report
 
-This document contains baseline benchmark results for Observatorium Loki under synthetic load.
+This document contains baseline benchmark results for Loki under synthetic load.
 
 ## Table of Contents
 
@@ -35,6 +35,17 @@ This document contains baseline benchmark results for Observatorium Loki under s
     - [QPS Ingester](#qps-ingester-aggregates)
     - [QPS BoltDB Shipper](#qps-boltdb-shipper-aggregates)
     - [Latency](#latency-ingester-aggregates)
+- [Scenario 4: Logs-Based Dashboard](#scenario-4-logs-based-dashboard)
+  - [Component Query Frontend](#component-query-frontend-dashboard-reads)
+    - [QPS](#qps-query-frontend-dashboard-reads)
+    - [Latency](#latency-query-frontend-dashboard-reads)
+  - [Component Querier](#component-querier-dashboard-reads)
+    - [QPS](#qps-querier-dashboard-reads)
+    - [Latency](#latency-querier-dashboard-reads)
+  - [Component Ingester](#component-ingester-dashboard-reads)
+    - [QPS Ingester](#qps-ingester-dashboard-reads)
+    - [QPS BoltDB Shipper](#qps-boltdb-shipper-dashboard-reads)
+    - [Latency](#latency-ingester-dashboard-reads)
 
 ---
 
@@ -45,7 +56,7 @@ Generated using profile:
 
 ---
 
-## Results
+## Benchmark Results
 
 ### Scenario 1: High Volume Writes
 
@@ -333,3 +344,110 @@ Query:
 > 100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="loki-ingester", method="gRPC", route="/logproto.Querier/QuerySample", status_code="success"}[1m])) / sum by (job) (rate(loki_request_duration_seconds_count{job="loki-ingester", method="gRPC", route="/logproto.Querier/QuerySample", status_code="success"}[1m])))
 
 ![./All-ingester-successful-query-sample-aggregate-avg.gnuplot.png](./All-ingester-successful-query-sample-aggregate-avg.gnuplot.png)
+
+---
+
+### Scenario 4: Logs-based Dashboard
+
+#### Component: Query Frontend Dashboard Reads
+
+##### QPS: Query Frontend Dashboard Reads
+
+Query:
+> sum(rate(loki_request_duration_seconds_count{job="loki-query-frontend", route="loki_api_v1_series|api_prom_series|api_prom_query|api_prom_label|api_prom_label_name_values|loki_api_v1_query|loki_api_v1_query_range|loki_api_v1_labels|loki_api_v1_label_name_values", status_code=~"2.*"}[1m]))
+
+![./All-query-frontend-2xx-dashboard-reads-QPS.gnuplot.png](./All-query-frontend-2xx-dashboard-reads-QPS.gnuplot.png)
+
+##### Latency: Query Frontend Dashboard Reads
+
+###### P99
+
+Query:
+> histogram_quantile(0.99, sum by (job, le) (rate(loki_request_duration_seconds_bucket{job="loki-query-frontend", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])))
+
+![./All-query-frontend-2xx-dashboard-reads-p99.gnuplot.png](./All-query-frontend-2xx-dashboard-reads-p99.gnuplot.png)
+
+###### P50
+
+Query:
+> histogram_quantile(0.50, sum by (job, le) (rate(loki_request_duration_seconds_bucket{job="loki-query-frontend", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])))
+
+![./All-query-frontend-2xx-dashboard-reads-p50.gnuplot.png](./All-query-frontend-2xx-dashboard-reads-p50.gnuplot.png)
+
+###### Average
+
+Query:
+> 100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="loki-query-frontend", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])) / sum by (job) (rate(loki_request_duration_seconds_count{job="loki-query-frontend", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])))
+
+![./All-query-frontend-2xx-dashboard-reads-avg.gnuplot.png](./All-query-frontend-2xx-dashboard-reads-avg.gnuplot.png)
+
+#### Component: Querier Dashboard Reads
+
+##### QPS: Querier Dashboard Reads
+
+Query:
+> sum(rate(loki_request_duration_seconds_count{job="loki-querier", route="loki_api_v1_series|api_prom_series|api_prom_query|api_prom_label|api_prom_label_name_values|loki_api_v1_query|loki_api_v1_query_range|loki_api_v1_labels|loki_api_v1_label_name_values", status_code=~"2.*"}[1m]))
+
+![./All-querier-2xx-dashboard-reads-QPS.gnuplot.png](./All-querier-2xx-dashboard-reads-QPS.gnuplot.png)
+
+##### Latency: Querier Dashboard Reads
+
+###### P99
+
+Query:
+> histogram_quantile(0.99, sum by (job, le) (rate(loki_request_duration_seconds_bucket{job="loki-querier", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])))
+
+![./All-querier-2xx-dashboard-reads-p99.gnuplot.png](./All-querier-2xx-dashboard-reads-p99.gnuplot.png)
+
+###### P50
+
+Query:
+> histogram_quantile(0.50, sum by (job, le) (rate(loki_request_duration_seconds_bucket{job="loki-querier", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])))
+
+![./All-querier-2xx-dashboard-reads-p50.gnuplot.png](./All-querier-2xx-dashboard-reads-p50.gnuplot.png)
+
+###### Average
+
+Query:
+> 100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="loki-querier", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])) / sum by (job) (rate(loki_request_duration_seconds_count{job="loki-querier", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])))
+
+![./All-querier-2xx-dashboard-reads-avg.gnuplot.png](./All-querier-2xx-dashboard-reads-avg.gnuplot.png)
+
+#### Component: Ingester Dashboard Reads
+
+##### QPS: Ingester Dashboard Reads
+
+Query:
+> sum(rate(loki_request_duration_seconds_count{job="loki-ingester", route="/logproto.Querier/Query|/logproto.Querier/QuerySample|/logproto.Querier/Label|/logproto.Querier/Series", status_code=~"success"}[1m]))
+
+![./All-ingester-successful-dashboard-reads-QPS.gnuplot.png](./All-ingester-successful-dashboard-reads-QPS.gnuplot.png)
+
+##### QPS: BoltDB Shipper Dashboard Reads
+
+Query:
+> sum(rate(loki_request_duration_seconds_count{job="loki-ingester", operation="QUERY", status_code=~"success"}[1m]))
+
+![./All-boltdb-shipper-successful-dashboard-reads-QPS.gnuplot.png](./All-boltdb-shipper-successful-dashboard-reads-QPS.gnuplot.png)
+
+##### Latency: Ingester Dashboard Reads
+
+###### P99
+
+Query:
+> histogram_quantile(0.99, sum by (job, le) (rate(loki_request_duration_seconds_bucket{job="loki-ingester", method="gRPC", route="/logproto.Querier/QuerySample", status_code="success"}[1m])))
+
+![./All-ingester-successful-dashboard-reads-p99.gnuplot.png](./All-ingester-successful-dashboard-reads-p99.gnuplot.png)
+
+###### P50
+
+Query:
+> histogram_quantile(0.50, sum by (job, le) (rate(loki_request_duration_seconds_bucket{job="loki-ingester", method="gRPC", route="/logproto.Querier/QuerySample", status_code="success"}[1m])))
+
+![./All-ingester-successful-dashboard-reads-p50.gnuplot.png](./All-ingester-successful-dashboard-reads-p50.gnuplot.png)
+
+###### Average
+
+Query:
+> 100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="loki-ingester", method="gRPC", route="/logproto.Querier/QuerySample", status_code="success"}[1m])) / sum by (job) (rate(loki_request_duration_seconds_count{job="loki-ingester", method="gRPC", route="/logproto.Querier/QuerySample", status_code="success"}[1m])))
+
+![./All-ingester-successful-dashboard-reads-avg.gnuplot.png](./All-ingester-successful-dashboard-reads-avg.gnuplot.png)


### PR DESCRIPTION
This PR adds a new benchmark for a logs-based dashboard. The development environment configuration declares eight queries based on the synthetic random log lines produced by the writers:
- The sum of the rate of all components by level
- The sum of the rate for component `devopsend` by level
- The sum of the rate for component `fullstackend` by level
- The sum of the rate for component `frontend` by level
- The sum of the rate for component `backend` by level
- The sum of the rate for all panic messages
- The count of all panic messages
- The top ten errors by components