### PR TITLE
Rewrite reader instance based on rakyll/hey

### DIFF
--- a/benchmarks/high_volume_aggregate_test.go
+++ b/benchmarks/high_volume_aggregate_test.go
@@ -35,6 +35,7 @@ var _ = Describe("Scenario: High Volume Aggregate", func() {
 
 		beforeOnce.Do(func() {
 			totalSamples = scenarioCfg.Samples.Total
+			readerDuration := time.Duration(int64(scenarioCfg.Samples.Total) * int64(scenarioCfg.Samples.Interval))
 
 			writerCfg := scenarioCfg.Writers
 			readerCfg := scenarioCfg.Readers
@@ -56,7 +57,7 @@ var _ = Describe("Scenario: High Volume Aggregate", func() {
 
 			// Deploy the query clients
 			for id, query := range readerCfg.Queries {
-				err = querier.Deploy(k8sClient, benchCfg.Querier, readerCfg, benchCfg.Loki.QueryURL(), id, query)
+				err = querier.Deploy(k8sClient, benchCfg.Querier, readerCfg, benchCfg.Loki.QueryURL(), id, query, readerDuration)
 				Expect(err).Should(Succeed(), "Failed to deploy querier")
 			}
 

--- a/benchmarks/high_volume_reads_test.go
+++ b/benchmarks/high_volume_reads_test.go
@@ -36,6 +36,7 @@ var _ = Describe("Scenario: High Volume Reads", func() {
 
 		beforeOnce.Do(func() {
 			totalSamples = scenarioCfg.Samples.Total
+			readerDuration := time.Duration(int64(scenarioCfg.Samples.Total) * int64(scenarioCfg.Samples.Interval))
 
 			writerCfg := scenarioCfg.Writers
 			readerCfg := scenarioCfg.Readers
@@ -57,7 +58,7 @@ var _ = Describe("Scenario: High Volume Reads", func() {
 
 			// Deploy the query clients
 			for id, query := range readerCfg.Queries {
-				err = querier.Deploy(k8sClient, benchCfg.Querier, readerCfg, benchCfg.Loki.QueryRangeURL(), id, query)
+				err = querier.Deploy(k8sClient, benchCfg.Querier, readerCfg, benchCfg.Loki.QueryRangeURL(), id, query, readerDuration)
 				Expect(err).Should(Succeed(), "Failed to deploy querier")
 			}
 

--- a/benchmarks/logs_based_dashboard_test.go
+++ b/benchmarks/logs_based_dashboard_test.go
@@ -35,6 +35,7 @@ var _ = Describe("Scenario: Logs-Based Dashboard", func() {
 
 		beforeOnce.Do(func() {
 			totalSamples = scenarioCfg.Samples.Total
+			readerDuration := time.Duration(int64(scenarioCfg.Samples.Total) * int64(scenarioCfg.Samples.Interval))
 
 			writerCfg := scenarioCfg.Writers
 			readerCfg := scenarioCfg.Readers
@@ -56,7 +57,7 @@ var _ = Describe("Scenario: Logs-Based Dashboard", func() {
 
 			// Deploy the query clients
 			for id, query := range readerCfg.Queries {
-				err = querier.Deploy(k8sClient, benchCfg.Querier, readerCfg, benchCfg.Loki.QueryRangeURL(), id, query)
+				err = querier.Deploy(k8sClient, benchCfg.Querier, readerCfg, benchCfg.Loki.QueryRangeURL(), id, query, readerDuration)
 				Expect(err).Should(Succeed(), "Failed to deploy querier")
 			}
 

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -7,7 +7,7 @@ logger:
 querier:
   name: querier
   namespace: default
-  image: docker.io/curlimages/curl:7.72.0
+  image: quay.io/periklis/hey:latest
   tenantId: observatorium
 
 metrics:
@@ -34,9 +34,10 @@ scenarios:
       replicas: 10
       throughput: 100
     readers:
-      replicas: 2
+      replicas: 1
+      throughput: 2
       queries:
-        sumRateByLevel: 'query=sum(rate({component!=""}[1h])) by (level)'
+        sumRateByLevel: 'sum(rate({component!=""}[1h])) by (level)'
       startThreshold: 1024000
   highVolumeWrites:
     enabled: true
@@ -57,11 +58,12 @@ scenarios:
       replicas: 10
       throughput: 100
     readers:
-      replicas: 2
+      replicas: 1
+      throughput: 2
       queries:
-        topTenComponents: 'query=topk(10, sum(rate({component!=""}[1h])) by (level))'
-        countOverTime: 'query=count_over_time({component!=""}[1h])'
-        bytesOverTime: 'query=bytes_over_time({component!=""}[1h])'
+        topTenComponents: 'topk(10, sum(rate({component!=""}[1h])) by (level))'
+        countOverTime: 'count_over_time({component!=""}[1h])'
+        bytesOverTime: 'bytes_over_time({component!=""}[1h])'
       startThreshold: 1024000
   logsBasedDashboard:
     enabled: true
@@ -74,13 +76,14 @@ scenarios:
       throughput: 100
     readers:
       replicas: 1
+      throughput: 2
       queries:
-        sumRateByLevel: 'query=sum(rate({component!=""}[1m])) by (level)'
-        devopsend: 'query=sum(rate({component="devopsend"}[1m])) by (level)'
-        fullstackend: 'query=sum(rate({component="fullstackend"}[1m])) by (level)'
-        frontend: 'query=sum(rate({component="frontend"}[1m])) by (level)'
-        backend: 'query=sum(rate({component="backend"}[1m])) by (level)'
-        allpanics: 'query=sum(rate({msg=~"panic.*"}[1m]))'
-        countpanics: 'query=count_over_time({msg=~"panic.*"}[5m])'
-        topTenErrors: 'query=topk(10, sum(rate({component!="", level="error"}[1h])) by (component))'
+        sumRateByLevel: 'sum(rate({component!=""}[1m])) by (level)'
+        devopsend: 'sum(rate({component="devopsend"}[1m])) by (level)'
+        fullstackend: 'sum(rate({component="fullstackend"}[1m])) by (level)'
+        frontend: 'sum(rate({component="frontend"}[1m])) by (level)'
+        backend: 'sum(rate({component="backend"}[1m])) by (level)'
+        allpanics: 'sum(rate({msg=~"panic.*"}[1m]))'
+        countpanics: 'count_over_time({msg=~"panic.*"}[5m])'
+        topTenErrors: 'topk(10, sum(rate({component!="", level="error"}[1h])) by (component))'
       startThreshold: 1024000

--- a/config/observatorium-logs-stage.yaml
+++ b/config/observatorium-logs-stage.yaml
@@ -7,7 +7,7 @@ logger:
 querier:
   name: querier
   namespace: observatorium-logs-stage
-  image: docker.io/curlimages/curl:7.72.0
+  image: quay.io/periklis/hey:latest
   tenantId: observatorium
 
 metrics:
@@ -27,22 +27,24 @@ scenarios:
   highVolumeReads:
     enabled: true
     samples:
-      interval: "30s"
-      range: "300s"
+      interval: "15s"
+      range: "1m"
       total: 10
     writers:
       replicas: 10
       throughput: 100
     readers:
-      replicas: 2
+      replicas: 1
+      throughput: 10
       queries:
-        sumRateByLevel: 'query=sum(rate({component!=""}[1h])) by (level)'
+        sumRateByLevel: 'sum(rate({component!=""}[5m])) by (level)'
+        sumRateErrosOnly: 'sum(rate({component!="", level="error"}[5m]))'
       startThreshold: 1024000
   highVolumeWrites:
     enabled: true
     samples:
-      interval: "30s"
-      range: "300s"
+      interval: "15s"
+      range: "1m"
       total: 10
     writers:
       replicas: 10
@@ -50,37 +52,39 @@ scenarios:
   highVolumeAggregate:
     enabled: true
     samples:
-      interval: "30s"
-      range: "300s"
-      total: 10
-    writers:
-      replicas: 10
-      throughput: 100
-    readers:
-      replicas: 2
-      queries:
-        topTenComponents: 'query=topk(10, sum(rate({component!=""}[1h])) by (level))'
-        countOverTime: 'query=count_over_time({component!=""}[1h])'
-        bytesOverTime: 'query=bytes_over_time({component!=""}[1h])'
-      startThreshold: 1024000
-  logsBasedDashboard:
-    enabled: true
-    samples:
-      interval: "30s"
-      range: "300s"
+      interval: "15s"
+      range: "1m"
       total: 10
     writers:
       replicas: 10
       throughput: 100
     readers:
       replicas: 1
+      throughput: 10
       queries:
-        sumRateByLevel: 'query=sum(rate({component!=""}[1m])) by (level)'
-        devopsend: 'query=sum(rate({component="devopsend"}[1m])) by (level)'
-        fullstackend: 'query=sum(rate({component="fullstackend"}[1m])) by (level)'
-        frontend: 'query=sum(rate({component="frontend"}[1m])) by (level)'
-        backend: 'query=sum(rate({component="backend"}[1m])) by (level)'
-        allpanics: 'query=sum(rate({msg=~"panic.*"}[1m]))'
-        countpanics: 'query=count_over_time({msg=~"panic.*"}[5m])'
-        topTenErrors: 'query=topk(10, sum(rate({component!="", level="error"}[1h])) by (component))'
+        topTenComponents: 'topk(10, sum(rate({component!=""}[5m])) by (level))'
+        countOverTime: 'count_over_time({component!=""}[5m])'
+        bytesOverTime: 'bytes_over_time({component!=""}[5m])'
+      startThreshold: 1024000
+  logsBasedDashboard:
+    enabled: true
+    samples:
+      interval: "15s"
+      range: "1m"
+      total: 10
+    writers:
+      replicas: 10
+      throughput: 100
+    readers:
+      replicas: 1
+      throughput: 10
+      queries:
+        sumRateByLevel: 'sum(rate({component!=""}[1m])) by (level)'
+        devopsend: 'sum(rate({component="devopsend"}[1m])) by (level)'
+        fullstackend: 'sum(rate({component="fullstackend"}[1m])) by (level)'
+        frontend: 'sum(rate({component="frontend"}[1m])) by (level)'
+        backend: 'sum(rate({component="backend"}[1m])) by (level)'
+        allpanics: 'sum(rate({msg=~"panic.*"}[1m]))'
+        countpanics: 'count_over_time({msg=~"panic.*"}[1m])'
+        topTenErrors: 'topk(10, sum(rate({component!="", level="error"}[1m])) by (component))'
       startThreshold: 1024000

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,9 +85,10 @@ type Writers struct {
 }
 
 type Readers struct {
-	Replicas       int32             `yaml:"replicas"`
-	Queries        map[string]string `yaml:"queries"`
-	StartThreshold float64           `yaml:"startThreshold"`
+	Replicas         int32             `yaml:"replicas"`
+	Queries          map[string]string `yaml:"queries"`
+	StartThreshold   float64           `yaml:"startThreshold"`
+	QueriesPerSecond int32             `yaml:"throughput"`
 }
 
 type Samples struct {

--- a/internal/metrics/client.go
+++ b/internal/metrics/client.go
@@ -71,7 +71,7 @@ func NewClient(url string, timeout time.Duration) (Client, error) {
 
 func (c *client) requestDurationAvg(job, method, route, code string, duration model.Duration) (float64, error) {
 	query := fmt.Sprintf(
-		`100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="%s", method="%s", route="%s", status_code=~"%s"}[%s])) / sum by (job) (rate(loki_request_duration_seconds_count{job="%s", method="%s", route="%s", status_code=~"%s"}[%s])))`,
+		`(sum(rate(loki_request_duration_seconds_sum{job="%s", method="%s", route="%s", status_code=~"%s"}[%s])) / sum(rate(loki_request_duration_seconds_count{job="%s", method="%s", route="%s", status_code=~"%s"}[%s])))`,
 		job, method, route, code, duration,
 		job, method, route, code, duration,
 	)

--- a/reports/README.template
+++ b/reports/README.template
@@ -88,7 +88,7 @@ Query:
 ###### Average
 
 Query:
-> 100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="loki-distributor", method="POST", route="loki_api_v1_push", status_code=~"2.*"}[1m])) / sum by (job) (rate(loki_request_duration_seconds_count{job="loki-distributor", method="POST", route="loki_api_v1_push", status_code=~"2.*"}[1m])))
+> (sum(rate(loki_request_duration_seconds_sum{job="loki-distributor", method="POST", route="loki_api_v1_push", status_code=~"2.*"}[1m])) / sum(rate(loki_request_duration_seconds_count{job="loki-distributor", method="POST", route="loki_api_v1_push", status_code=~"2.*"}[1m])))
 
 ![./All-distributor-2xx-push-avg.gnuplot.png](./All-distributor-2xx-push-avg.gnuplot.png)
 
@@ -127,7 +127,7 @@ Query:
 ###### Average
 
 Query:
-> 100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="loki-ingester", method="gRPC", route="/logproto.Pusher/Push", status_code="success"}[1m])) / sum by (job) (rate(loki_request_duration_seconds_count{job="loki-ingester", method="gRPC", route="/logproto.Pusher/Push", status_code="success"}[1m])))
+> (sum(rate(loki_request_duration_seconds_sum{job="loki-ingester", method="gRPC", route="/logproto.Pusher/Push", status_code="success"}[1m])) / sum(rate(loki_request_duration_seconds_count{job="loki-ingester", method="gRPC", route="/logproto.Pusher/Push", status_code="success"}[1m])))
 
 ![./All-ingester-successful-GRPC-push-avg.gnuplot.png](./All-ingester-successful-GRPC-push-avg.gnuplot.png)
 
@@ -163,7 +163,7 @@ Query:
 ###### Average
 
 Query:
-> 100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="loki-query-frontend", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])) / sum by (job) (rate(loki_request_duration_seconds_count{job="loki-query-frontend", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])))
+> (sum(rate(loki_request_duration_seconds_sum{job="loki-query-frontend", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])) / sum(rate(loki_request_duration_seconds_count{job="loki-query-frontend", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])))
 
 ![./All-query-frontend-2xx-reads-avg.gnuplot.png](./All-query-frontend-2xx-reads-avg.gnuplot.png)
 
@@ -195,7 +195,7 @@ Query:
 ###### Average
 
 Query:
-> 100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="loki-querier", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])) / sum by (job) (rate(loki_request_duration_seconds_count{job="loki-querier", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])))
+> (sum(rate(loki_request_duration_seconds_sum{job="loki-querier", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])) / sum(rate(loki_request_duration_seconds_count{job="loki-querier", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])))
 
 ![./All-querier-2xx-query-range-avg.gnuplot.png](./All-querier-2xx-query-range-avg.gnuplot.png)
 
@@ -234,7 +234,7 @@ Query:
 ###### Average
 
 Query:
-> 100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="loki-ingester", method="gRPC", route="/logproto.Querier/QuerySample", status_code="success"}[1m])) / sum by (job) (rate(loki_request_duration_seconds_count{job="loki-ingester", method="gRPC", route="/logproto.Querier/QuerySample", status_code="success"}[1m])))
+> (sum(rate(loki_request_duration_seconds_sum{job="loki-ingester", method="gRPC", route="/logproto.Querier/QuerySample", status_code="success"}[1m])) / sum(rate(loki_request_duration_seconds_count{job="loki-ingester", method="gRPC", route="/logproto.Querier/QuerySample", status_code="success"}[1m])))
 
 ![./All-ingester-successful-query-sample-avg.gnuplot.png](./All-ingester-successful-query-sample-avg.gnuplot.png)
 
@@ -270,7 +270,7 @@ Query:
 ###### Average
 
 Query:
-> 100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="loki-query-frontend", method="GET", route="loki_api_v1_query", status_code=~"2.*"}[1m])) / sum by (job) (rate(loki_request_duration_seconds_count{job="loki-query-frontend", method="GET", route="loki_api_v1_query", status_code=~"2.*"}[1m])))
+> (sum(rate(loki_request_duration_seconds_sum{job="loki-query-frontend", method="GET", route="loki_api_v1_query", status_code=~"2.*"}[1m])) / sum(rate(loki_request_duration_seconds_count{job="loki-query-frontend", method="GET", route="loki_api_v1_query", status_code=~"2.*"}[1m])))
 
 ![./All-query-frontend-2xx-aggregate-reads-avg.gnuplot.png](./All-query-frontend-2xx-aggregate-reads-avg.gnuplot.png)
 
@@ -302,7 +302,7 @@ Query:
 ###### Average
 
 Query:
-> 100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="loki-querier", method="GET", route="loki_api_v1_query", status_code=~"2.*"}[1m])) / sum by (job) (rate(loki_request_duration_seconds_count{job="loki-querier", method="GET", route="loki_api_v1_query", status_code=~"2.*"}[1m])))
+> (sum(rate(loki_request_duration_seconds_sum{job="loki-querier", method="GET", route="loki_api_v1_query", status_code=~"2.*"}[1m])) / sum(rate(loki_request_duration_seconds_count{job="loki-querier", method="GET", route="loki_api_v1_query", status_code=~"2.*"}[1m])))
 
 ![./All-querier-2xx-query-aggregate-avg.gnuplot.png](./All-querier-2xx-query-aggregate-avg.gnuplot.png)
 
@@ -341,7 +341,7 @@ Query:
 ###### Average
 
 Query:
-> 100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="loki-ingester", method="gRPC", route="/logproto.Querier/QuerySample", status_code="success"}[1m])) / sum by (job) (rate(loki_request_duration_seconds_count{job="loki-ingester", method="gRPC", route="/logproto.Querier/QuerySample", status_code="success"}[1m])))
+> (sum(rate(loki_request_duration_seconds_sum{job="loki-ingester", method="gRPC", route="/logproto.Querier/QuerySample", status_code="success"}[1m])) / sum(rate(loki_request_duration_seconds_count{job="loki-ingester", method="gRPC", route="/logproto.Querier/QuerySample", status_code="success"}[1m])))
 
 ![./All-ingester-successful-query-sample-aggregate-avg.gnuplot.png](./All-ingester-successful-query-sample-aggregate-avg.gnuplot.png)
 
@@ -377,7 +377,7 @@ Query:
 ###### Average
 
 Query:
-> 100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="loki-query-frontend", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])) / sum by (job) (rate(loki_request_duration_seconds_count{job="loki-query-frontend", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])))
+> (sum(rate(loki_request_duration_seconds_sum{job="loki-query-frontend", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])) / sum(rate(loki_request_duration_seconds_count{job="loki-query-frontend", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])))
 
 ![./All-query-frontend-2xx-dashboard-reads-avg.gnuplot.png](./All-query-frontend-2xx-dashboard-reads-avg.gnuplot.png)
 
@@ -409,7 +409,7 @@ Query:
 ###### Average
 
 Query:
-> 100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="loki-querier", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])) / sum by (job) (rate(loki_request_duration_seconds_count{job="loki-querier", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])))
+> (sum(rate(loki_request_duration_seconds_sum{job="loki-querier", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])) / sum(rate(loki_request_duration_seconds_count{job="loki-querier", method="GET", route="loki_api_v1_query_range", status_code=~"2.*"}[1m])))
 
 ![./All-querier-2xx-dashboard-reads-avg.gnuplot.png](./All-querier-2xx-dashboard-reads-avg.gnuplot.png)
 
@@ -448,6 +448,6 @@ Query:
 ###### Average
 
 Query:
-> 100 * (sum by (job) (rate(loki_request_duration_seconds_sum{job="loki-ingester", method="gRPC", route="/logproto.Querier/QuerySample", status_code="success"}[1m])) / sum by (job) (rate(loki_request_duration_seconds_count{job="loki-ingester", method="gRPC", route="/logproto.Querier/QuerySample", status_code="success"}[1m])))
+> (sum(rate(loki_request_duration_seconds_sum{job="loki-ingester", method="gRPC", route="/logproto.Querier/QuerySample", status_code="success"}[1m])) / sum(rate(loki_request_duration_seconds_count{job="loki-ingester", method="gRPC", route="/logproto.Querier/QuerySample", status_code="success"}[1m])))
 
 ![./All-ingester-successful-dashboard-reads-avg.gnuplot.png](./All-ingester-successful-dashboard-reads-avg.gnuplot.png)


### PR DESCRIPTION
This PR addresses a rewrite of the reader instance deployment to leverage the configuration options of a proper http load testing tool. In particular rakyll/hey is used to benefit of controlling options like QPS and duration. The obvious impact is that users' writing benchmarking configurations can not controle the QPS for readers declaratively with a single replica rather than spinning multiple replicas per query. In addition this PR replaces the former reader tool namely `curl`. 