### PR TITLE
Configuring CircleCi to use workflows for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
 version: 2
+
 jobs:
   lint:
     machine:
@@ -9,6 +10,7 @@ jobs:
       - run:
           name: lint
           command: make lint
+
   build:
     machine:
       image: ubuntu-2204:2022.07.1
@@ -29,3 +31,10 @@ jobs:
           path: reports
       - store_artifacts:
           path: reports
+
+workflows:
+  version: 2
+  lint_and_test:
+    jobs:
+      - lint
+      - build

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,7 +2,6 @@
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - errcheck
@@ -15,15 +14,11 @@
     - ineffassign
     - nakedret
     - nolintlint
-    - scopelint
     - staticcheck
-    - structcheck
     - typecheck
     - unconvert
-    - varcheck
     - gocritic
     - unused
     - misspell
     - stylecheck
     - whitespace
-    - wsl

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ help: ## Display this help.
 
 ##@ Ingredients
 lint: $(GOLANGCI_LINT) ## Lint the code
-	@$(GOLANGCI_LINT) run
+	@$(GOLANGCI_LINT) run --timeout=4m
 
 $(REPORT_DIR):
 	@mkdir -p $(REPORT_DIR)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ export PATH:=$(GOBIN):$(PATH)
 include .bingo/Variables.mk
 
 export GOROOT=$(shell go env GOROOT)
-export GOFLAGS=-mod=vendor
 export GO111MODULE=on
 
 export REPORT_DIR?=$(CURDIR)/reports/$(shell date +%Y-%m-%d-%H-%M-%S)

--- a/benchmarks/benchmarks_suite_test.go
+++ b/benchmarks/benchmarks_suite_test.go
@@ -24,8 +24,6 @@ var (
 	k8sClient     client.Client
 	metricsClient metrics.Client
 
-	reportDir string
-
 	defaultLatchRange = "5m"
 
 	defaultRetry        = 5 * time.Second

--- a/benchmarks/high_volume_reads_test.go
+++ b/benchmarks/high_volume_reads_test.go
@@ -36,9 +36,9 @@ var _ = Describe("Scenario: High Volume Reads", func() {
 
 		defaultRange := sampleCfg.Range
 
-		samplingCfg := gmeasure.SamplingConfig {
-			N: sampleCfg.Total,
-			Duration: sampleCfg.Interval * time.Duration(sampleCfg.Total + 1),
+		samplingCfg := gmeasure.SamplingConfig{
+			N:                   sampleCfg.Total,
+			Duration:            sampleCfg.Interval * time.Duration(sampleCfg.Total+1),
 			MinSamplingInterval: sampleCfg.Interval,
 		}
 

--- a/benchmarks/high_volume_writes_test.go
+++ b/benchmarks/high_volume_writes_test.go
@@ -30,9 +30,9 @@ var _ = Describe("Scenario: High Volume Writes", func() {
 		sampleCfg := scenarioCfg.Samples
 
 		defaultRange := sampleCfg.Range
-		samplingCfg := gmeasure.SamplingConfig {
-			N: sampleCfg.Total,
-			Duration: sampleCfg.Interval * time.Duration(sampleCfg.Total + 1),
+		samplingCfg := gmeasure.SamplingConfig{
+			N:                   sampleCfg.Total,
+			Duration:            sampleCfg.Interval * time.Duration(sampleCfg.Total+1),
 			MinSamplingInterval: sampleCfg.Interval,
 		}
 
@@ -44,7 +44,7 @@ var _ = Describe("Scenario: High Volume Writes", func() {
 				err = k8s.WaitForReadyDeployment(k8sClient, loggerCfg.Namespace, loggerCfg.Name, writerCfg.Replicas, defaultRetry, defaultTimeout)
 				Expect(err).Should(Succeed(), "Failed to wait for ready logger deployment")
 
-				DeferCleanup(func(){
+				DeferCleanup(func() {
 					err := logger.Undeploy(k8sClient, benchCfg.Logger)
 					Expect(err).Should(Succeed(), "Failed to delete logger deployment")
 				})


### PR DESCRIPTION
This PR updates the circleci config to use workflows. This separates the tests into `lint` and `build`.