### PR TITLE
Using logcli binary deployment

### DIFF
--- a/benchmarks/high_volume_writes_test.go
+++ b/benchmarks/high_volume_writes_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Scenario: High Volume Writes", func() {
 				err := loadclient.CreateDeployment(k8sClient, generatorCfg)
 				Expect(err).Should(Succeed(), "Failed to deploy logger")
 
-				err = utils.WaitForReadyDeployment(k8sClient, loggerCfg.Namespace, loggerCfg.Name, generatorCfg.Replicas, defaultRetry, defaultTimeout)
+				err = utils.WaitForReadyDeployment(k8sClient, loggerCfg.Namespace, loggerCfg.Name, defaultRetry, defaultTimeout)
 				Expect(err).Should(Succeed(), "Failed to wait for ready logger deployment")
 
 				DeferCleanup(func() {

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -7,7 +7,7 @@ logger:
 querier:
   name: querier
   namespace: default
-  image: quay.io/openshift-logging/cluster-logging-load-client:latest
+  image: docker.io/grafana/logcli:2.6.1-amd64
   tenantId: observatorium
 
 metrics:

--- a/config/ocp-observatorium-test.yaml
+++ b/config/ocp-observatorium-test.yaml
@@ -7,7 +7,7 @@ logger:
 querier:
   name: querier
   namespace: observatorium-logs-test
-  image: quay.io/openshift-logging/cluster-logging-load-client:latest
+  image: docker.io/grafana/logcli:2.6.1-amd64
   tenantId: observatorium
 
 metrics:

--- a/internal/loadclient/deployment.go
+++ b/internal/loadclient/deployment.go
@@ -3,7 +3,6 @@ package loadclient
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/observatorium/loki-benchmarks/internal/config"
 
@@ -35,31 +34,6 @@ func GeneratorConfig(scenarioCfg *config.Writers, cfg *config.Logger, pushURL st
 
 	args = append(args, fmt.Sprintf("--%s=%s", "url", pushURL))
 	args = append(args, fmt.Sprintf("--%s=%s", "tenant", cfg.TenantID))
-
-	for k, v := range scenarioCfg.Args {
-		args = append(args, fmt.Sprintf("--%s=%s", k, v))
-	}
-
-	config.Args = args
-
-	return config
-}
-
-func QuerierConfig(scenarioCfg *config.Readers, cfg *config.Querier, url, query, id string) DeploymentConfig {
-	querierName := fmt.Sprintf("%s-%s", cfg.Name, strings.ToLower(id))
-
-	config := defaultConfig(querierName, cfg.Namespace, cfg.Image, scenarioCfg.Replicas)
-	config.Labels = map[string]string{
-		"app": "loki-benchmarks-querier",
-	}
-
-	args := []string{
-		"query",
-	}
-
-	args = append(args, fmt.Sprintf("--%s=%s", "url", url))
-	args = append(args, fmt.Sprintf("--%s=%s", "tenant", cfg.TenantID))
-	args = append(args, fmt.Sprintf("--%s=%s", "queries", query))
 
 	for k, v := range scenarioCfg.Args {
 		args = append(args, fmt.Sprintf("--%s=%s", k, v))

--- a/internal/querier/deployment.go
+++ b/internal/querier/deployment.go
@@ -1,0 +1,107 @@
+package querier
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/observatorium/loki-benchmarks/internal/config"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func CreateQueriers(
+	scenarioCfg *config.Readers,
+	cfg *config.Querier,
+	clientURL string,
+	queries map[string]string,
+) []client.Object {
+	window := "1m"
+	if queryRange, ok := scenarioCfg.Args["query-duration"]; ok {
+		window = queryRange
+	}
+
+	var dpls []client.Object
+	for id, query := range queries {
+		dpls = append(dpls, NewLogCLIDeployment(
+			fmt.Sprintf("%s-querier", strings.ToLower(id)),
+			cfg.Namespace, cfg.Image, "", clientURL, cfg.TenantID, query, window,
+			scenarioCfg.Replicas,
+		),
+		)
+	}
+
+	return dpls
+}
+
+func NewLogCLIDeployment(
+	name, namespace, image, serviceAccount, clientURL, tenantID, query, window string,
+	replicas int32,
+) *appsv1.Deployment {
+	spec := corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:  "logcli",
+				Image: image,
+				Command: []string{
+					"/bin/sh",
+				},
+				Args: []string{
+					"-c",
+					fmt.Sprintf(`while true; do logcli query '%s' --since=%s; sleep 30; done`, query, window),
+				},
+				Env: []corev1.EnvVar{
+					{
+						Name:  "LOKI_ORG_ID",
+						Value: tenantID,
+					},
+					{
+						Name:  "LOKI_ADDR",
+						Value: clientURL,
+					},
+				},
+			},
+		},
+	}
+
+	if serviceAccount != "" {
+		spec.ServiceAccountName = serviceAccount
+		spec.Containers[0].Env = append(spec.Containers[0].Env,
+			corev1.EnvVar{
+				Name:  "LOKI_BEARER_TOKEN_FILE",
+				Value: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+			},
+			corev1.EnvVar{
+				Name:  "LOKI_CA_CERT_PATH",
+				Value: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt",
+			},
+		)
+	}
+
+	labels := map[string]string{
+		"app": "loki-benchmarks-querier",
+	}
+
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: pointer.Int32Ptr(replicas),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: spec,
+			},
+		},
+	}
+}


### PR DESCRIPTION
This PR changes the querier from the custom cluster-load client to the binary provided by Grafana. Ultimately, the ability to create more load by the queriers can be done by creating more replicas. This also helps to decouple the system for some scenarios a bit more.